### PR TITLE
Add direct access to client-types' records #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [نصب](#نصب)
 - [نحوه استفاده](#نحوه-استفاده)
   - [دانلود سابقه سهم‌ها](#دانلود-سابقه-سهم‌ها)
+  - [دانلود سابقه معاملات حقیقی و حقوقی](#دانلود-سابقه-معاملات-حقیقی-و-حقوقی-به-صورت-مجزا)
   - [ماژول Ticker](#ماژول-Ticker)
   - [اطلاعات حقیقی و حقوقی](#اطلاعات-حقیقی-و-حقوقی)
   - [پکیج های مورد نیاز](#required-packages)
@@ -85,6 +86,52 @@ import pytse_client as tse
 tse.download(symbols="وبملت", write_to_csv=True)
 tse.download(symbols="وبملت", write_to_csv=True, include_jdate=True)
 tse.download(symbols=["وبملت", "ولملت"], write_to_csv=True)
+```
+
+</div>
+
+### دانلود سابقه معاملات حقیقی و حقوقی به صورت مجزا
+برای دانلود سابقه معاملات حقیقی و حقوقی برای تمامی نمادها  میتوان از تابع زیر استفاده کرد
+
+<div dir="ltr">
+
+```python
+from pytse_client.download import download_client_types_record  
+  
+if __name__ == '__main__':  
+
+  records_dict = download_client_types_record("all")
+  print(records["فولاد"])
+  #Output
+date         individual_buy_count  ... individual_ownership_change
+                            
+2020-09-01                36298  ...                   -691857.0
+2020-08-31                58185  ...                  83789408.0
+2020-08-26                  461  ...                  21647730.0
+2020-08-25                 1248  ...                  14716846.0
+2020-08-24                38291  ...                -238454702.0
+...                         ...  ...                         ...
+2008-12-02                    7  ...                    -10000.0
+2008-12-01                    8  ...                         0.0
+2008-11-30                   10  ...                    -12781.0
+2008-11-29                  116  ...                   4596856.0
+2008-11-26                   14  ...                    -20000.0
+
+[2518 rows x 17 columns]
+
+```
+
+</div>
+
+مشابه تابع قبلی میتوان نتایج را ذخیره کرد
+
+<div dir="ltr">
+
+```python
+if __name__ == '__main__':  
+   
+  #Records are saved as a .csv file with the same name of ticer's 
+  records = download_client_types_records("فولاد", write_to_csv=True)
 ```
 
 </div>

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ tse.download(symbols=["وبملت", "ولملت"], write_to_csv=True)
 <div dir="ltr">
 
 ```python
-from pytse_client.download import download_client_types_record  
+from pytse_client import download_client_types_records  
   
 if __name__ == '__main__':  
 
-  records_dict = download_client_types_record("all")
-  print(records["فولاد"])
+  records_dict = download_client_types_records("all")
+  print(records_dict["فولاد"])
   #Output
 date         individual_buy_count  ... individual_ownership_change
                             
@@ -128,6 +128,7 @@ date         individual_buy_count  ... individual_ownership_change
 <div dir="ltr">
 
 ```python
+from pytse_client import download_client_types_records
 if __name__ == '__main__':  
    
   #Records are saved as a .csv file with the same name of ticer's 

--- a/pytse_client/__init__.py
+++ b/pytse_client/__init__.py
@@ -1,3 +1,4 @@
 from .download import download
+from .download import download_client_types_records
 from .symbols_data import all_symbols
 from .ticker import Ticker

--- a/pytse_client/config.py
+++ b/pytse_client/config.py
@@ -2,4 +2,5 @@ import os
 
 
 DATA_BASE_PATH = "tickers_data"
+CLIENT_TYPES_DATA_BASE_PATH = "client_types_data"
 pytse_dir = os.path.dirname(__file__)

--- a/pytse_client/download.py
+++ b/pytse_client/download.py
@@ -9,6 +9,7 @@ import jdatetime
 
 from pytse_client import config, symbols_data, tse_settings
 from pytse_client.utils import requests_retry_session
+from pytse_client.tse_settings import TSE_CLIENT_TYPE_DATA_URL
 
 
 def download(
@@ -26,13 +27,7 @@ def download(
     with ThreadPoolExecutor(max_workers=10) as executor:
         for symbol in symbols:
             ticker_index = symbols_data.get_ticker_index(symbol)
-            if ticker_index is None:
-                ticker_index = get_symbol_id(symbol)
-                if ticker_index is None:
-                    raise Exception("Can not found ticker name")
-                else:
-                    symbols_data.append_symbol_to_file(ticker_index, symbol)
-
+            _handle_ticker_index(symbol, ticker_index)
             future = executor.submit(
                 download_ticker_daily_record,
                 ticker_index
@@ -45,15 +40,8 @@ def download(
                 columns=FIELD_MAPPINGS
             )
             df = df.drop(columns=["<PER>", "<OPEN>", "<TICKER>"])
-            df.date = pd.to_datetime(df.date, format="%Y%m%d")
-            if include_jdate:
-                df['jdate'] = ""
-                df.jdate = df.date.apply(
-                    lambda gregorian:
-                    jdatetime.date.fromgregorian(date=gregorian))
-            df.set_index("date", inplace=True)
+            _adjust_data_frame(df, include_jdate)
             df_list[symbol] = df
-
             if write_to_csv:
                 Path(base_path).mkdir(parents=True, exist_ok=True)
                 df.to_csv(
@@ -62,6 +50,16 @@ def download(
     if len(df_list) != len(symbols):
         print("Warning, download did not complete, re-run the code")
     return df_list
+
+
+def _adjust_data_frame(df, include_jdate):
+    df.date = pd.to_datetime(df.date, format="%Y%m%d")
+    if include_jdate:
+        df['jdate'] = ""
+        df.jdate = df.date.apply(
+            lambda gregorian:
+            jdatetime.date.fromgregorian(date=gregorian))
+    df.set_index("date", inplace=True)
 
 
 def download_ticker_daily_record(ticker_index: str):
@@ -74,6 +72,79 @@ def download_ticker_daily_record(ticker_index: str):
 
     data = StringIO(response.text)
     return pd.read_csv(data)
+
+
+def download_client_types_records(
+        symbols: Union[List, str],
+        write_to_csv: bool = False,
+        include_jdate: bool = False,
+        base_path: str = config.CLIENT_TYPES_DATA_BASE_PATH
+):
+    if symbols == "all":
+        symbols = symbols_data.all_symbols()
+    elif isinstance(symbols, str):
+        symbols = [symbols]
+
+    df_list = {}
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for symbol in symbols:
+            ticker_index = symbols_data.get_ticker_index(symbol)
+            _handle_ticker_index(symbol, ticker_index)
+            future = executor.submit(
+                download_ticker_client_types_record,
+                ticker_index
+            )
+            df: pd.DataFrame = future.result()
+            _adjust_data_frame(df, include_jdate)
+            df_list[symbol] = df
+            if write_to_csv:
+                Path(base_path).mkdir(parents=True, exist_ok=True)
+                df.to_csv(f'{base_path}/{symbol}.csv')
+    return df_list
+
+
+def _handle_ticker_index(symbol, ticker_index):
+    if ticker_index is None:
+        ticker_index = get_symbol_id(symbol)
+        if ticker_index is None:
+            raise Exception("Can not found ticker name")
+        else:
+            symbols_data.append_symbol_to_file(ticker_index, symbol)
+
+
+def download_ticker_client_types_record(ticker_index: str):
+    data = _extract_ticker_client_types_data(ticker_index)
+    client_types_data_frame = pd.DataFrame(data, columns=[
+        "date",
+        "individual_buy_count", "corporate_buy_count",
+        "individual_sell_count", "corporate_sell_count",
+        "individual_buy_vol", "corporate_buy_vol",
+        "individual_sell_vol", "corporate_sell_vol",
+        "individual_buy_value", "corporate_buy_value",
+        "individual_sell_value", "corporate_sell_value"
+    ])
+    for i in [
+        "individual_buy_", "individual_sell_",
+        "corporate_buy_", "corporate_sell_"
+    ]:
+        client_types_data_frame[f"{i}mean_price"] = (
+                client_types_data_frame[f"{i}value"].astype(float) /
+                client_types_data_frame[f"{i}vol"].astype(float)
+        )
+    client_types_data_frame["individual_ownership_change"] = (
+            client_types_data_frame["corporate_sell_vol"].astype(float) -
+            client_types_data_frame["corporate_buy_vol"].astype(float)
+    )
+    return client_types_data_frame
+
+
+def _extract_ticker_client_types_data(ticker_index: str) -> List:
+    url = TSE_CLIENT_TYPE_DATA_URL.format(ticker_index)
+    response = requests_retry_session().get(url, timeout=5)
+    data = response.text.split(";")
+    data = [row.split(",") for row in data]
+    return data
 
 
 def to_arabic(string: str):
@@ -89,7 +160,7 @@ def get_symbol_id(symbol_name: str):
         raise Exception("Sorry, tse server did not respond")
 
     symbol_full_info = response.text.split(';')[0].split(',')
-    if(to_arabic(symbol_name) == symbol_full_info[0].strip()):
+    if (to_arabic(symbol_name) == symbol_full_info[0].strip()):
         return symbol_full_info[2]  # symbol id
     return None
 

--- a/pytse_client/examples/client_types.py
+++ b/pytse_client/examples/client_types.py
@@ -1,11 +1,13 @@
 """
-    This example shows how to download and get tse tickers client types records
-    specifically (as a 'Pandas DataFrame' object), and easily save them in .csv format.
+    This example shows how to download and get tse tickers
+    client types records specifically (as a 'Pandas DataFrame' object),
+    and easily save them in .csv format.
 """
 from pytse_client.download import download_client_types_records
 
 if __name__ == '__main__':
-    # Download all tickers clients types at once.This function returns a dictionary.
+    # Download all tickers clients types at once.
+    # This function returns a dictionary.
     records_1 = download_client_types_records("all")
 
     # Download specific tickers client types records

--- a/pytse_client/examples/client_types.py
+++ b/pytse_client/examples/client_types.py
@@ -1,0 +1,19 @@
+"""
+    This example shows how to download and get tse tickers client types records
+    specifically (as a 'Pandas DataFrame' object), and easily save them in .csv format.
+"""
+from pytse_client.download import download_client_types_records
+
+if __name__ == '__main__':
+    # Download all tickers clients types at once.This function returns a dictionary.
+    records_1 = download_client_types_records("all")
+
+    # Download specific tickers client types records
+    records_2 = download_client_types_records(["فولاد", "ذوب"])
+    print(records_2["فولاد"])
+    print("Fuldad: ", records_2["فولاد"], sep="\n")
+    print("Zoob: ", records_2["ذوب"], sep="\n")
+
+    # Download and save tickers client types records
+    records_3 = download_client_types_records("فولاد", write_to_csv=True)
+    print("Foolad:", records_3["فولاد"], sep="\n")

--- a/pytse_client/examples/client_types.py
+++ b/pytse_client/examples/client_types.py
@@ -3,7 +3,7 @@
     client types records specifically (as a 'Pandas DataFrame' object),
     and easily save them in .csv format.
 """
-from pytse_client.download import download_client_types_records
+from pytse_client import download_client_types_records
 
 if __name__ == '__main__':
     # Download all tickers clients types at once.

--- a/pytse_client/ticker.py
+++ b/pytse_client/ticker.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from pytse_client import config, download, symbols_data, tse_settings, utils
 from pytse_client.tse_settings import TSE_CLIENT_TYPE_DATA_URL
+from pytse_client.download import download_ticker_client_types_record
 
 RealtimeTickerInfo = collections.namedtuple(
     'RealtimeTickerInfo',
@@ -136,31 +137,4 @@ class Ticker:
 
     @property
     def client_types(self):
-        response = utils.requests_retry_session().get(
-            self._client_types_url, timeout=10
-        )
-        data = response.text.split(";")
-        data = [row.split(",") for row in data]
-        client_types_data_frame = pd.DataFrame(data, columns=[
-            "date",
-            "individual_buy_count", "corporate_buy_count",
-            "individual_sell_count", "corporate_sell_count",
-            "individual_buy_vol", "corporate_buy_vol",
-            "individual_sell_vol", "corporate_sell_vol",
-            "individual_buy_value", "corporate_buy_value",
-            "individual_sell_value", "corporate_sell_value"
-        ])
-        for i in [
-            "individual_buy_", "individual_sell_",
-            "corporate_buy_", "corporate_sell_"
-        ]:
-            client_types_data_frame[f"{i}mean_price"] = (
-                    client_types_data_frame[f"{i}value"].astype(float) /
-                    client_types_data_frame[f"{i}vol"].astype(float)
-            )
-        client_types_data_frame["individual_ownership_change"] = (
-                client_types_data_frame["corporate_sell_vol"].astype(float) -
-                client_types_data_frame["corporate_buy_vol"].astype(float)
-        )
-
-        return client_types_data_frame
+        return download_ticker_client_types_record(self._index)


### PR DESCRIPTION
## What?

I've added functionalities to download tickers' client types' records (all at once or separately) and save them as .csv files. #7 

## Why?

This feature makes it possible to access client-types records *directly* and *specifically* (instead of getting them through an instance of the *Ticker* class) just with a single function call.

## How?
The implementation of the main added function, *download_client_types_records()*, is quite similar to the existing *download()* one, except that it gets and handles data from another source.

## Example?
I've added a new example that shows how to work with the new feature.


## Documentation?
The README.md file has been updated to the new changes.

@Glyphack I'll appreciate if you take a look and let me know about any comments or problems.
