### PR TITLE
Fix ZeroDivisionError in p_e_ratio in ticker.py

### DIFF
--- a/pytse_client/ticker.py
+++ b/pytse_client/ticker.py
@@ -100,7 +100,7 @@ class Ticker:
         """
         adj_close = self.get_ticker_real_time_info_response().adj_close
         eps = self.eps
-        if adj_close is None or eps is None:
+        if adj_close is None or eps is None or eps == 0:
             return None
         return self.get_ticker_real_time_info_response().adj_close / self.eps
 


### PR DESCRIPTION
سلام
در زمان دریافت p_e_ratio، برای نمادهایی که eps آنها صفر است روی ticker.py با خطا مواجه می شیم (به عنوان مثال نماد آرمانی): 

  File "C:\ProgramData\Anaconda3\lib\site-packages\pytse_client\ticker.py", line 105, in p_e_ratio
    return self.get_ticker_real_time_info_response().adj_close / self.eps

ZeroDivisionError: float division by zero
![error_ticker_pytse_client_ZeroDivisionError](https://user-images.githubusercontent.com/46574030/111078298-febe0d00-8509-11eb-8b86-881fe79ee1c2.png)
